### PR TITLE
The am335x_evm.sh script will, through autoconfigure_usb0.sh, read the

### DIFF
--- a/boot/am335x_evm.sh
+++ b/boot/am335x_evm.sh
@@ -117,39 +117,10 @@ fi
 
 sleep 3
 
-#Wheezy Image:
-if [ -f /etc/default/udhcpd ] ; then
-	unset udhcp_disabled
-	udhcp_disabled=$(grep \#DHCPD_ENABLED /etc/default/udhcpd || true)
-	if [ "x${udhcp_disabled}" = "x" ] ; then
-		sed -i -e 's:DHCPD_ENABLED="no":#DHCPD_ENABLED="no":g' /etc/default/udhcpd
-	fi
-fi
 
-if [ -f /etc/udhcpd.conf ] ; then
-	#Distro default...
-	unset deb_udhcpd
-	deb_udhcpd=$(grep Sample /etc/udhcpd.conf || true)
-	if [ ! "x${deb_udhcpd}" = "x" ] ; then
-		mv /etc/udhcpd.conf /etc/udhcpd.conf.bak
+# Auto-configuring the usb0 network interface:
+$(dirname $0)/autoconfigure_usb0.sh
 
-		echo "start      192.168.7.1" > /etc/udhcpd.conf
-		echo "end        192.168.7.1" >> /etc/udhcpd.conf
-		echo "interface  usb0" >> /etc/udhcpd.conf
-		echo "max_leases 1" >> /etc/udhcpd.conf
-		echo "option subnet 255.255.255.252" >> /etc/udhcpd.conf
-	fi
-	/etc/init.d/udhcpd restart
-
-	/sbin/ifconfig usb0 192.168.7.2 netmask 255.255.255.252 || true
-	/usr/sbin/udhcpd -S /etc/udhcpd.conf
-fi
-
-#Jessie Image:
-if [ -f /etc/dnsmasq.d/usb0-dhcp ] ; then
-	/sbin/ifconfig usb0 192.168.7.2 netmask 255.255.255.252 || true
-	systemctl restart dnsmasq
-fi
 
 eth0_addr=$(ip addr list eth0 |grep "inet " |cut -d' ' -f6|cut -d/ -f1 2>/dev/null || true)
 usb0_addr=$(ip addr list usb0 |grep "inet " |cut -d' ' -f6|cut -d/ -f1 2>/dev/null || true)

--- a/boot/autoconfigure_usb0.sh
+++ b/boot/autoconfigure_usb0.sh
@@ -1,0 +1,191 @@
+#!/bin/sh -e
+#
+# Copyright (c) 2015 Per Dalgas Jakobsen <pdj@knaldgas.dk>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+#Based on:
+# am355x_evm.sh by Robert Nelson
+
+
+#
+# Auto-configuring the usb0 network interface:
+#
+# If udhcpd has been installed it will be used for usb0.
+# If udhcpd has not been installed, and dnsmasq is installed, dnsmasq
+# is checked and possibly configured with usb0.
+#
+
+# Get usb0 set-up from /etc/network/interfaces - Used for
+# auto-configuring the usb0 networking.
+
+unset deb_etc_dir \
+      deb_network_interfaces \
+      deb_udhcpd_conf \
+      deb_udhcpd_default \
+      deb_dnsmasq_conf \
+      deb_dnsmasq_dir
+
+
+# Separated /etc variable to ease test on host system (by changing
+# etc_dir during test).
+deb_etc_dir=/etc
+
+deb_udhcpd_conf=${deb_etc_dir}/udhcpd.conf
+deb_udhcpd_default=${deb_etc_dir}/default/udhcpd
+
+deb_dnsmasq_conf=${deb_etc_dir}/dnsmasq.conf
+deb_dnsmasq_dir=${deb_etc_dir}/dnsmasq.d
+
+deb_network_interfaces=${deb_etc_dir}/network/interfaces
+
+
+
+deb_configure_udhcpd ()
+{
+	# Function expects udhcpd to be installed, and usb_address,
+	# usb_gateway and usb_netmask to be set.
+	#
+	# udhcpd is installed, we may use it for usb0 networking.
+
+	unset deb_udhcpd_disabled_regex \
+	      deb_deb_udhcpd_interface \
+	      deb_deb_udhcpd_start \
+	      deb_deb_udhcpd_mask
+
+	# Ensure that udhcpd has been disable. (comment out if needed).
+	deb_udhcpd_disabled_regex='^[[:space:]]*DHCPD_ENABLED[[:space:]]*=[[:space:]]*"no"'
+	$( ( grep -iqE "${deb_udhcpd_disabled_regex}" ${deb_udhcpd_default} && \
+	    sed -ir "s/${deb_udhcpd_disabled_regex}/#\0/g" ${deb_udhcpd_default} ) || \
+	  true)
+
+	# Get current configured interface
+	deb_udhcpd_interface=$(sed -nr 's/^[[:space:]]*interface[[:space:]]+(usb0)/\1/p' ${deb_udhcpd_conf})
+
+	# If udhcpd is configured for usb0 we will take control.
+	if [ "x${deb_udhcpd_interface}" = "xusb0" ]; then
+		# Modify /etc/udhcpd.congf if ip-addresses has changed.
+		deb_udhcpd_start=$(sed -nr 's/^[[:space:]]*start[[:space:]]+([0-9.]+)/\1/p' ${deb_udhcpd_conf})
+		deb_udhcpd_mask=$(sed -nr 's/^[[:space:]]*option subnet[[:space:]]+([0-9.]+)/\1/p' ${deb_udhcpd_conf})
+		if [ "x${deb_usb_gateway}${deb_usb_netmask}" != "x${deb_udhcpd_start}${deb_udhcpd_mask}" ] ; then
+			mv ${deb_udhcpd_conf} ${deb_udhcpd_conf}.bak
+			cat <<EOF > ${deb_udhcpd_conf}
+# Managed by $0 - Do not modify unless you know what you are doing!
+start      ${deb_usb_gateway}
+end        ${deb_usb_gateway}
+interface  usb0
+max_leases 1
+option subnet ${deb_usb_netmask}
+EOF
+		fi
+
+		# Will start or restart udhcpd
+		/sbin/ifconfig usb0 ${deb_usb_address} netmask ${deb_usb_netmask} || true
+		/usr/sbin/udhcpd -S ${deb_udhcpd_conf}
+	fi
+}
+
+
+deb_configure_dnsmasq ()
+{
+	# Function expects dnsmasq to be installed.
+	# dnsmasq is installed, we may use it for usb0 networking.
+
+	unset deb_generated_dnsmasq_file \
+	      deb_usb0_handled \
+	      deb_dnsmasq_warning
+
+	deb_generated_dnsmasq_file=usb0-dhcp.generated
+
+	# Check if any interface references usb0.
+	# Only dnsmasq default directory and patterns are searched !!!
+	deb_usb0_handled=$(grep -rlE --exclude='*~' --exclude='.*' \
+				--exclude=${deb_generated_dnsmasq_file} \
+				--exclude=.${deb_generated_dnsmasq_file} \
+				--exclude=${deb_generated_dnsmasq_file}~ \
+				'^[[:space:]]*interface[[:space:]]*=[[:space:]]*usb0' \
+				${deb_dnsmasq_dir} || true)
+	if [ "x$deb_usb0_handled" = "x" ]; then
+		# No-one else is managing usb0, so we will:
+		# We will only generate the file if it already exist or:
+		#   if not, only if the file has not been disabled.
+		if [ -f ${deb_dnsmasq_dir}/${deb_generated_dnsmasq_file} -o \
+		     ! -f ${deb_dnsmasq_dir}/${deb_generated_dnsmasq_file}~ -a \
+		     ! -f ${deb_dnsmasq_dir}/.${deb_generated_dnsmasq_file} ] ; then
+			cat <<EOF > ${deb_dnsmasq_dir}/${deb_generated_dnsmasq_file}
+# Managed by $0 - Do not modify unless you know what you are doing!
+# Disable this file by prepending "." or appending "~" to the filename.
+# Removing the file will just cause $0 to recreated!
+#
+# disable DNS by setting port to 0
+port=0
+interface=usb0
+#one address range
+dhcp-range=${deb_usb_gateway},${deb_usb_gateway}
+dhcp-option=3
+except-interface=lo
+listen-address=${deb_usb_address}
+EOF
+			/sbin/ifconfig usb0 ${deb_usb_address} netmask ${deb_usb_netmask} || true
+		fi
+
+		deb_dnsmasq_warning="# NOTE: dnsmasq is partly configured by $0 - Changing configuration directory or file inclusion/exclusion may affect its functionality!"
+		grep -qi "${deb_dnsmasq_warning}" ${deb_dnsmasq_conf} || \
+			echo "\n${deb_dnsmasq_warning}" >>${deb_dnsmasq_conf}
+
+		systemctl restart dnsmasq
+	fi
+}
+
+
+
+###  Script start ###
+
+unset deb_iface_range_regex \
+      deb_usb_address \
+      deb_usb_gateway \
+      deb_usb_netmask
+
+deb_iface_range_regex="/^[[:space:]]*iface[[:space:]]+usb0/,/iface/"
+
+deb_usb_address=$(sed -nr "${deb_iface_range_regex} p" ${deb_network_interfaces} |\
+		  sed -nr "s/^[[:space:]]*address[[:space:]]+([0-9.]+)/\1/p")
+
+deb_usb_gateway=$(sed -nr "${deb_iface_range_regex} p" ${deb_network_interfaces} |\
+		  sed -nr "s/^[[:space:]]*gateway[[:space:]]+([0-9.]+)/\1/p")
+
+deb_usb_netmask=$(sed -nr "${deb_iface_range_regex} p" ${deb_network_interfaces} |\
+		  sed -nr "s/^[[:space:]]*netmask[[:space:]]+([0-9.]+)/\1/p")
+
+
+# Check if usb0 was specified in /etc/network/interfaces
+if [ "x${deb_usb_address}" != "x" -a\
+     "x${deb_usb_gateway}" != "x" -a\
+     "x${deb_usb_netmask}" != "x" ] ; then
+	# usb0 is specified!
+	if [ -f ${deb_udhcpd_conf} -a -f ${deb_udhcpd_default} ]; then
+		deb_configure_udhcpd
+
+	elif [ -f ${deb_dnsmasq_conf} -a -f ${deb_dnsmasq_dir}/README ]; then
+		deb_configure_dnsmasq
+
+	fi
+fi
+
+#


### PR DESCRIPTION
network-values for usb0 from /etc/network/interfaces, instead of
having them hardcoded into the script itself.

If udhcpd is installed, changing /etc/network/interfaces will cause
the scripts to reconfigure /etc/udhcpd.conf (provided that the udhcpd
interface is set to usb0).

If dnsmasq is installed (and udhcpd is not), changing
/etc/network/interfaces will cause the scripts to reconfigure
/etc/dnsmasq.d/usb0-dhcp.generated accordingly, only if no other
configuration file references usb0.  The usb0-dhcp.generated filename
can be appended with ~ (tilde) to disable further reconfiguration.

Signed-off-by: Per Dalgas Jakobsen <pdj@knaldgas.dk>