### PR TITLE
Fix for 4.1 Kernel

### DIFF
--- a/boot/capemgr.sh
+++ b/boot/capemgr.sh
@@ -7,7 +7,7 @@ fi
 #CAPE="cape-bone-proto"
 
 cape_list=$(echo ${CAPE} | sed "s/ //g" | sed "s/,/ /g")
-capemgr=$(ls /sys/devices/bone_capemgr.*/slots 2> /dev/null || true)
+capemgr=$(ls /sys/devices/platform/bone_capemgr/slots 2> /dev/null || true)
 
 load_overlay () {
 	echo ${overlay} > ${capemgr}


### PR DESCRIPTION
Trying to use a custom cape in 4.1 and added to /etc/default/capemgr had no effect.

The script it runs is using the old 3.x path to the slots.

Changing to this works