### PR TITLE
Fix eewiki flasher

### DIFF
--- a/tools/eMMC/bbb-eMMC-flasher-eewiki-ext4.sh
+++ b/tools/eMMC/bbb-eMMC-flasher-eewiki-ext4.sh
@@ -419,7 +419,7 @@ copy_rootfs () {
 		message="-----------------------------" ; broadcast
 
 		flush_cache
-		halt -f
+		halt
 	fi
 }
 

--- a/tools/eMMC/bbb-eMMC-flasher-eewiki-ext4.sh
+++ b/tools/eMMC/bbb-eMMC-flasher-eewiki-ext4.sh
@@ -406,7 +406,7 @@ copy_rootfs () {
 		message="debug: enabled" ; broadcast
 		inf_loop
 	else
-		umount /tmp || umount -l /tmp
+		#umount /tmp || umount -l /tmp
 		if [ -e /sys/class/leds/beaglebone\:green\:usr0/trigger ] ; then
 			echo default-on > /sys/class/leds/beaglebone\:green\:usr0/trigger
 			echo default-on > /sys/class/leds/beaglebone\:green\:usr1/trigger

--- a/tools/eMMC/bbb-eMMC-flasher-eewiki-ext4.sh
+++ b/tools/eMMC/bbb-eMMC-flasher-eewiki-ext4.sh
@@ -325,7 +325,7 @@ copy_boot () {
 	flush_cache
 	umount /tmp/boot/ || umount -l /tmp/boot/ || write_failure
 	flush_cache
-	umount /boot/uboot || umount -l /boot/uboot
+	umount /boot/uboot || umount -l /boot/uboot || true
 }
 
 copy_rootfs () {


### PR DESCRIPTION
Some directories that the script tries to unmount aren't mounted, and as a result the script fails prematurely before finishing the eMMC flash. 

As a result, using the script to flash the eMMC when booted with [the latest image](http://builds.beagleboard.org/images/master/08132bf0d0cb284d1148c5d329fe3c8e1aaee44d/bone-debian-7.9-lxde-4gb-armhf-2015-11-12-4gb.img.xz) fails. The changes here are the ones needed to make that succeed.