### PR TITLE
Allow choosing FAT boot filesystem type

### DIFF
--- a/tools/eMMC/bbb-eMMC-flasher-eewiki-ext4.sh
+++ b/tools/eMMC/bbb-eMMC-flasher-eewiki-ext4.sh
@@ -486,7 +486,7 @@ partition_drive () {
 
 	dd_bootloader
 
-	boot_fstype="ext4"
+	boot_fstype=${boot_fstype:-ext4}
 
 	if [ "x${boot_fstype}" = "xfat" ] ; then
 		conf_boot_startmb=${conf_boot_startmb:-"1"}
@@ -573,6 +573,16 @@ clear
 message="-----------------------------" ; broadcast
 message="Version: [${version_message}]" ; broadcast
 message="-----------------------------" ; broadcast
+
+if [[ "$1" == --boot_fstype* ]] ; then
+    boot_fstype=${2:-$1}
+    boot_fstype=${boot_fstype#*=}
+    case $boot_fstype in
+        fat | ext4) ;;
+        *) echo "boot_fstype must be fat or ext4"; exit 2 ;;
+    esac
+    message="Using $boot_fstype for boot filesystem" ; broadcast
+fi
 
 check_eeprom
 check_running_system


### PR DESCRIPTION
Rather than hardcoding the codeblock for creating two partitions to be always bypassed, make that the default, and allow optionally choosing with a command line option (--boot_fstype={fat,ext4}).