### PR TITLE
Fixes dnsmasq configuration to work with wireless interfaces too

### DIFF
--- a/boot/autoconfigure_usb0.sh
+++ b/boot/autoconfigure_usb0.sh
@@ -127,13 +127,16 @@ deb_configure_dnsmasq ()
 # Removing the file will just cause $0 to recreated!
 #
 # disable DNS by setting port to 0
-port=0
+#port=0
 #one address range
 dhcp-range=usb,${deb_usb_address},${deb_usb_gateway}
 dhcp-option=usb,3
-except-interface=lo
-except-interface=eth0
-listen-address=${deb_usb_address}
+# either use listen-address, then include 127.0.0.1
+#listen-address=${deb_usb_address}
+#listen-address=127.0.0.1
+# or bind to the usb0 interface (which implicitly also binds to lo)
+interface=usb0
+no-dhcp-interface=lo
 EOF
 			/sbin/ifconfig usb0 ${deb_usb_address} netmask ${deb_usb_netmask} || true
 		fi


### PR DESCRIPTION
Setting `port=0` disables dnsmasq' DNS, which in turn renders DNS non-functional, because so long as dnsmasq is running /etc/resolv.conf lists 127.0.0.1 (i.e., dnsmasq) as the DNS server. (mDNS will still work, though.) Adding `except-interface=wlan0` does not rescue this; according to the documentation, `except-interface`, `interface` and `listen-address` are three different alternatives to determine where dnsmasq listens, hence mixing them doesn't really make sense. Using `interface=` will implicitly include the loopback interface, but using `listen-address` will _not_. Without lo or localhost being listened to by dnsmasq, DNS will not work.