### PR TITLE
autoconfigure_usb0: udhcpd 30 leases

### DIFF
--- a/boot/autoconfigure_usb0.sh
+++ b/boot/autoconfigure_usb0.sh
@@ -84,6 +84,8 @@ end        ${deb_usb_gateway}
 interface  usb0
 max_leases 1
 option subnet ${deb_usb_netmask}
+option domain local
+option lease 30
 EOF
 
 	# Will start or restart udhcpd


### PR DESCRIPTION
I'm tired of leases getting hung up between disconnects. This might be
due to MAC address changes, but a few extra DHCP requests seems like
a small price to pay to ensure users aren't waiting around for minutes
on end to get a valid IP address on their machine.