### PR TITLE
added -c parms to mkfs to ensure bad blocks are detected and marked

### DIFF
--- a/tools/eMMC/bbb-eMMC-flasher-eewiki-12mb.sh
+++ b/tools/eMMC/bbb-eMMC-flasher-eewiki-12mb.sh
@@ -280,17 +280,17 @@ format_boot () {
 }
 
 format_root () {
-	message="mkfs.ext4 ${destination}p2 -L ${rootfs_label}" ; broadcast
+	message="mkfs.ext4 -c ${destination}p2 -L ${rootfs_label}" ; broadcast
 	echo "-----------------------------"
-	mkfs.ext4 ${destination}p2 -L ${rootfs_label}
+	mkfs.ext4 -c ${destination}p2 -L ${rootfs_label}
 	echo "-----------------------------"
 	flush_cache
 }
 
 format_single_root () {
-	message="mkfs.ext4 ${destination}p1 -L ${boot_label}" ; broadcast
+	message="mkfs.ext4 -c ${destination}p1 -L ${boot_label}" ; broadcast
 	echo "-----------------------------"
-	mkfs.ext4 ${destination}p1 -L ${boot_label}
+	mkfs.ext4 -c ${destination}p1 -L ${boot_label}
 	echo "-----------------------------"
 	flush_cache
 }

--- a/tools/eMMC/bbb-eMMC-flasher-eewiki-ext4.sh
+++ b/tools/eMMC/bbb-eMMC-flasher-eewiki-ext4.sh
@@ -433,7 +433,7 @@ partition_drive () {
 	if [ "x${test_mkfs}" = "x" ] ; then
 		unset ext4_options
 	else
-		ext4_options="-O ^metadata_csum,^64bit"
+		ext4_options="-c -O ^metadata_csum,^64bit"
 	fi
 
 	if [ "x${dd_spl_uboot_backup}" = "x" ] ; then

--- a/tools/eMMC/beaglebone-black-make-microSD-flasher-from-eMMC.sh
+++ b/tools/eMMC/beaglebone-black-make-microSD-flasher-from-eMMC.sh
@@ -432,7 +432,7 @@ partition_drive () {
 	if [ "x${test_mkfs}" = "x" ] ; then
 		unset ext4_options
 	else
-		ext4_options="-O ^metadata_csum,^64bit"
+		ext4_options="-c -O ^metadata_csum,^64bit"
 	fi
 
 	if [ "x${dd_spl_uboot_backup}" = "x" ] ; then

--- a/tools/eMMC/init-eMMC-flasher-from-usb-media-v1-bbgw.sh
+++ b/tools/eMMC/init-eMMC-flasher-from-usb-media-v1-bbgw.sh
@@ -194,17 +194,17 @@ format_boot () {
 }
 
 format_root () {
-	message="mkfs.ext4 ${destination}p2 -L ${rootfs_label}" ; broadcast
+	message="mkfs.ext4 -c ${destination}p2 -L ${rootfs_label}" ; broadcast
 	echo "-----------------------------"
-	mkfs.ext4 ${destination}p2 -L ${rootfs_label}
+	mkfs.ext4 -c ${destination}p2 -L ${rootfs_label}
 	echo "-----------------------------"
 	flush_cache
 }
 
 format_single_root () {
-	message="mkfs.ext4 ${destination}p1 -L ${boot_label}" ; broadcast
+	message="mkfs.ext4 -c ${destination}p1 -L ${boot_label}" ; broadcast
 	echo "-----------------------------"
-	mkfs.ext4 ${destination}p1 -L ${boot_label}
+	mkfs.ext4 -c ${destination}p1 -L ${boot_label}
 	echo "-----------------------------"
 	flush_cache
 }

--- a/tools/eMMC/init-eMMC-flasher-from-usb-media-v2-bbgw.sh
+++ b/tools/eMMC/init-eMMC-flasher-from-usb-media-v2-bbgw.sh
@@ -156,8 +156,8 @@ flash_emmc () {
 	sync
 	flush_cache
 
-	message="mkfs.ext4 -L rootfs ${destination}p1" ; broadcast
-	LC_ALL=C mkfs.ext4 -L rootfs ${destination}p1 || write_failure
+	message="mkfs.ext4 -c -L rootfs ${destination}p1" ; broadcast
+	LC_ALL=C mkfs.ext4 -c -L rootfs ${destination}p1 || write_failure
 	message="Erasing: ${destination} complete" ; broadcast
 	message="-----------------------------" ; broadcast
 

--- a/tools/eMMC/init-eMMC-flasher-from-usb-media.sh
+++ b/tools/eMMC/init-eMMC-flasher-from-usb-media.sh
@@ -156,8 +156,8 @@ flash_emmc () {
 	sync
 	flush_cache
 
-	message="mkfs.ext2 -L rootfs ${destination}p1" ; broadcast
-	LC_ALL=C mkfs.ext2 -L rootfs ${destination}p1 || write_failure
+	message="mkfs.ext2 -c -L rootfs ${destination}p1" ; broadcast
+	LC_ALL=C mkfs.ext2 -c -L rootfs ${destination}p1 || write_failure
 	message="Erasing: ${destination} complete" ; broadcast
 	message="-----------------------------" ; broadcast
 

--- a/tools/eMMC/init-eMMC-flasher-v2.sh
+++ b/tools/eMMC/init-eMMC-flasher-v2.sh
@@ -193,7 +193,7 @@ format_boot () {
 }
 
 format_root () {
-	mkfs.ext4 ${destination}p2 -L rootfs
+	mkfs.ext4 -c ${destination}p2 -L rootfs
 	flush_cache
 }
 

--- a/tools/eMMC/init-eMMC-flasher-v3-bbbw.sh
+++ b/tools/eMMC/init-eMMC-flasher-v3-bbbw.sh
@@ -491,7 +491,7 @@ partition_drive () {
 	if [ "x${test_mkfs}" = "x" ] ; then
 		unset ext4_options
 	else
-		ext4_options="-O ^metadata_csum,^64bit"
+		ext4_options="-c -O ^metadata_csum,^64bit"
 	fi
 
 	dd_bootloader

--- a/tools/eMMC/init-eMMC-flasher-v3-bbg.sh
+++ b/tools/eMMC/init-eMMC-flasher-v3-bbg.sh
@@ -465,7 +465,7 @@ partition_drive () {
 	if [ "x${test_mkfs}" = "x" ] ; then
 		unset ext4_options
 	else
-		ext4_options="-O ^metadata_csum,^64bit"
+		ext4_options="-c -O ^metadata_csum,^64bit"
 	fi
 
 	dd_bootloader

--- a/tools/eMMC/init-eMMC-flasher-v3-bbgw.sh
+++ b/tools/eMMC/init-eMMC-flasher-v3-bbgw.sh
@@ -491,7 +491,7 @@ partition_drive () {
 	if [ "x${test_mkfs}" = "x" ] ; then
 		unset ext4_options
 	else
-		ext4_options="-O ^metadata_csum,^64bit"
+		ext4_options="-c -O ^metadata_csum,^64bit"
 	fi
 
 	dd_bootloader

--- a/tools/eMMC/init-eMMC-flasher-v3-m10a.sh
+++ b/tools/eMMC/init-eMMC-flasher-v3-m10a.sh
@@ -465,7 +465,7 @@ partition_drive () {
 	if [ "x${test_mkfs}" = "x" ] ; then
 		unset ext4_options
 	else
-		ext4_options="-O ^metadata_csum,^64bit"
+		ext4_options="-c -O ^metadata_csum,^64bit"
 	fi
 
 	dd_bootloader

--- a/tools/eMMC/init-eMMC-flasher-v3-x15_b1.sh
+++ b/tools/eMMC/init-eMMC-flasher-v3-x15_b1.sh
@@ -465,7 +465,7 @@ partition_drive () {
 	if [ "x${test_mkfs}" = "x" ] ; then
 		unset ext4_options
 	else
-		ext4_options="-O ^metadata_csum,^64bit"
+		ext4_options="-c -O ^metadata_csum,^64bit"
 	fi
 
 	dd_bootloader

--- a/tools/eMMC/init-eMMC-flasher-v3.sh
+++ b/tools/eMMC/init-eMMC-flasher-v3.sh
@@ -465,7 +465,7 @@ partition_drive () {
 	if [ "x${test_mkfs}" = "x" ] ; then
 		unset ext4_options
 	else
-		ext4_options="-O ^metadata_csum,^64bit"
+		ext4_options="-c -O ^metadata_csum,^64bit"
 	fi
 
 	dd_bootloader


### PR DESCRIPTION
My BBGW had a few bad blocks on the eMMC.  Without the -c parameter to mkfs, flashing the image would fail partway through, leaving my device unbootable.  This adds approximately 1 minute to the flasher, but will solve problems where people cannot flash their BB.