### PR TITLE
Add CDC/ECM function to USB gadget

### DIFF
--- a/boot/am335x_evm.sh
+++ b/boot/am335x_evm.sh
@@ -467,6 +467,7 @@ use_libcomposite () {
 				#ls /sys/class/udc
 				echo musb-hdrc.0.auto > UDC
 				usb0="enable"
+				usb1="enable"
 				echo "${log} g_multi Created"
 			else
 				echo "${log} FIXME: need to bring down g_multi first, before running a second time."
@@ -557,7 +558,7 @@ use_old_g_multi () {
 	fi
 }
 
-unset usb0
+unset usb0 usb1
 
 #use libcomposite with v4.4.x+ kernel's...
 kernel_major=$(uname -r | cut -d. -f1 || true)
@@ -581,6 +582,12 @@ if [ "x${usb0}" = "xenable" ] ; then
 	echo "${log} Starting usb0 network"
 	# Auto-configuring the usb0 network interface:
 	$(dirname $0)/autoconfigure_usb0.sh || true
+fi
+
+if [ "x${usb1}" = "xenable" ] ; then
+	echo "${log} Starting usb1 network"
+	# Auto-configuring the usb1 network interface:
+	$(dirname $0)/autoconfigure_usb1.sh || true
 fi
 
 if [ -d /sys/class/tty/ttyGS0/ ] ; then

--- a/boot/am335x_evm.sh
+++ b/boot/am335x_evm.sh
@@ -435,6 +435,11 @@ use_libcomposite () {
 				# first byte of address must be even
 				echo ${cpsw_2_mac} > functions/rndis.usb0/host_addr
 				echo ${cpsw_1_mac} > functions/rndis.usb0/dev_addr
+
+				mkdir -p functions/ecm.usb0
+				echo ${cpsw_2_mac} > functions/ecm.usb0/host_addr
+				echo ${cpsw_1_mac} > functions/ecm.usb0/dev_addr
+
 				mkdir -p functions/acm.usb0
 
 				if [ "x${has_img_file}" = "xtrue" ] ; then
@@ -453,6 +458,7 @@ use_libcomposite () {
 				echo 500 > configs/c.1/MaxPower
 
 				ln -s functions/rndis.usb0 configs/c.1/
+				ln -s functions/ecm.usb0 configs/c.1/
 				ln -s functions/acm.usb0 configs/c.1/
 				if [ "x${has_img_file}" = "xtrue" ] ; then
 					ln -s functions/mass_storage.usb0 configs/c.1/

--- a/boot/autoconfigure_usb1.sh
+++ b/boot/autoconfigure_usb1.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 David Lechner <david@lechnology.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+
+#
+# Auto-configuring the usb1 network interface:
+#
+# usb1 is the CDC/ECM gadget connection. It is managed by ConnMan and uses
+# tethering so that it serves a DHCP address to attached hosts. The IPv4 subnet
+# used by ConnMan is not consistent, so hosts should connect using the mDNS
+# name (beaglebone.local) instead of an IP address.
+#
+
+# This is probably not needed if autoconfigure_usb0.sh is run first because it
+# also waits for /sys/class/net/usb0/
+until [ -d /sys/class/net/usb1/ ] ; do
+	sleep 1
+	echo "g_multi: waiting for /sys/class/net/usb1/"
+done
+
+# gadget is not supported by ConnMan provisioning files, so we have to do this
+# the ugly way. Advanced users can comment these line to gain full control of
+# the usb1 network interface.
+connmanctl enable gadget >/dev/null 2>&1
+connmanctl tether gadget on >/dev/null 2>&1


### PR DESCRIPTION
This adds a CDC/EMC USB networking function to the multifunction
USB gadget device. This is needed to get USB networking working on
macOS with no 3rd party drivers. It also works better than RNDIS on
Linux. Also, we will be changing the USB class of the RNDIS driver,
so it will no longer be detected by Linux, so CDC will be the only
networking interface that shows up on Linux.