### PR TITLE
Add a second USB gadget configuration for Linux

### DIFF
--- a/boot/am335x_evm.sh
+++ b/boot/am335x_evm.sh
@@ -464,6 +464,25 @@ use_libcomposite () {
 					ln -s functions/mass_storage.usb0 configs/c.1/
 				fi
 
+				# If Linux sees a device with RNDIS as the first
+				# interface and there is a second configuration,
+				# it will prefer the second configuration. OS X
+				# used to do the same, but it was broken in 10.11
+				# which is why we have to include the ecm in the
+				# first configuration (c.1). So, c.1 will be used
+				# on Windows and macOS >= 10.11 and c.2 will be
+				# used on Linux and macOS <= 10.10
+				mkdir -p configs/c.2/strings/0x409
+				echo "Multifunction without RNDIS" > configs/c.2/strings/0x409/configuration
+
+				echo 500 > configs/c.2/MaxPower
+
+				ln -s functions/ecm.usb0 configs/c.2/
+				ln -s functions/acm.usb0 configs/c.2/
+				if [ "x${has_img_file}" = "xtrue" ] ; then
+					ln -s functions/mass_storage.usb0 configs/c.2/
+				fi
+
 				#ls /sys/class/udc
 				echo musb-hdrc.0.auto > UDC
 				usb0="enable"


### PR DESCRIPTION
This adds a second USB gadget configuration that will be used by Linux.
Linux is smart enough to know that RNDIS is not nice, so if it sees RNDIS
as the first interface and it sees that there is a second USB configuration,
it will prefer the second configuration. This results in only the CDC ECM
interface being used on Linux (and older versions of macOS).