### PR TITLE
Fix autosetting default gateway and nameservers

### DIFF
--- a/boot/autoconfigure_usb0.sh
+++ b/boot/autoconfigure_usb0.sh
@@ -215,10 +215,9 @@ if [ "x${deb_usb_address}" != "x" -a\
 			deb_configure_dnsmasq
 
 		fi
-		${deb_post_up}
-
-		[ "x$deb_dns_nameservers" != "x" ] && echo nameserver $deb_dns_nameservers >> /etc/resolv.conf
 	fi
+	${deb_post_up}
+	[ "x$deb_dns_nameservers" != "x" ] && echo nameserver $deb_dns_nameservers >> /etc/resolv.conf
 fi
 
 #


### PR DESCRIPTION
Moved the "post_up" and "nameserver" setting lines outside of the if statement so that it runs regardless whether the usb_gadget folder exists or not.