### PR TITLE
Revert "Add support for new RNDIS configfs options in kernel 4.14"

### DIFF
--- a/boot/am335x_evm.sh
+++ b/boot/am335x_evm.sh
@@ -528,15 +528,6 @@ use_libcomposite () {
 				mkdir -p functions/ecm.usb0
 				echo ${cpsw_4_mac} > functions/ecm.usb0/host_addr
 				echo ${cpsw_5_mac} > functions/ecm.usb0/dev_addr
-				
-				# Starting with kernel 4.14, we can do this to match Microsoft's built-in driver.
-				# Earlier kernels require the patch below as a work-around instead:
-				# https://github.com/beagleboard/linux/commit/e94487c59cec8ba32dc1eb83900297858fdc590b
-				if [ -f functions/ecm.usb0/class ]; then
-					echo 239 > functions/ecm.usb0/class
-					echo 4 > functions/ecm.usb0/subclass
-					echo 1 > functions/ecm.usb0/protocol
-				fi
 
 				mkdir -p functions/acm.usb0
 


### PR DESCRIPTION
Reverts RobertCNelson/boot-scripts#64

I just realized that I did this for the wrong function, ecm instead of rndis.