### PR TITLE
Respect any existing ifup configuration when bringing 'usb1' online.

### DIFF
--- a/boot/autoconfigure_usb1.sh
+++ b/boot/autoconfigure_usb1.sh
@@ -44,4 +44,8 @@ done
 #connmanctl enable gadget >/dev/null 2>&1
 #connmanctl tether gadget on >/dev/null 2>&1
 
-/sbin/ifconfig usb1 192.168.6.2 netmask 255.255.255.252 || true
+# if there is any pre-existing config for usb1, use that;
+# otherwise use a static default
+grep -rqE '^\s*iface usb1 inet' /etc/network/interfaces* && /sbin/ifup usb1 \
+	|| /sbin/ifconfig usb1 192.168.6.2 netmask 255.255.255.252 \
+	|| true


### PR DESCRIPTION
User may have added an ifupdown configuration for 'usb1'.
In this case the user's assumption is that their ifupdown config
would be the one applied to the interface when brought up.

Maintain the default behavior as before: in absence of user directive
configure usb1 with the time-honored static IP.

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>