### PR TITLE
Allow user to disable /etc/dnsmasq.d/SoftAp0 creation using a dotfile.

### DIFF
--- a/boot/am335x_evm.sh
+++ b/boot/am335x_evm.sh
@@ -758,7 +758,8 @@ if [ ! "x${USB_NETWORK_DISABLED}" = "xyes" ]; then
 		if [ -d /sys/kernel/config/usb_gadget ] ; then
 			/etc/init.d/udhcpd stop || true
 
-			if [ -d /etc/dnsmasq.d/ ] ; then
+			# do not write if there is a .SoftAp0 file
+			if [ -d /etc/dnsmasq.d/ -a ! -e /etc/dnsmasq.d/.SoftAp0 ] ; then
 				echo "${log} dnsmasq: setting up for usb0/usb1"
 				disable_connman_dnsproxy
 


### PR DESCRIPTION
User may not want automatic creation/overwriting of dnsmasq SoftAp0 file,
allow disabling with a dotfile.

Signed-off-by: Sirio Balmelli <sirio@b-ad.ch>