### PR TITLE
Added missing 'not' in error messages when drive not detected

### DIFF
--- a/tools/grow_partition.sh
+++ b/tools/grow_partition.sh
@@ -41,7 +41,7 @@ fi
 if [ ! "x${root_drive}" = "x" ] ; then
 	boot_drive="${root_drive%?}1"
 else
-	echo "Error: script halting, could detect drive..."
+	echo "Error: script halting, could not detect drive..."
 	exit 1
 fi
 
@@ -100,7 +100,7 @@ expand_partition () {
 	elif [ "x${boot_drive}" = "x/dev/mmcblk1p1" ] ; then
 		drive="/dev/mmcblk1"
 	else
-		echo "Error: script halting, could detect drive..."
+		echo "Error: script halting, could not detect drive..."
 		exit 1
 	fi
 


### PR DESCRIPTION
The two error messages for when the drive could not be detected outputted
```
Error: script halting, could detect drive...
```
instead of
```
Error: script halting, could not detect drive...
```