### PR TITLE
Add support to the Gateway Cape for BeagleBone Black

### DIFF
--- a/boot/am335x_evm.sh
+++ b/boot/am335x_evm.sh
@@ -136,6 +136,10 @@ TI_AM335x_BeagleBone_Black)
 	cleanup_extra_docs
 	dnsmasq_usb0_usb1="enable"
 	;;
+TI_AM335x_BeagleBone_Black_Gateway_Cape)
+	has_wifi="enable"
+	cleanup_extra_docs
+	;;
 TI_AM335x_BeagleBone_Black_Wireless)
 	has_wifi="enable"
 	#recovers 82MB of space


### PR DESCRIPTION
There was no support for the Wireless Connectivity Cape for BeagleBone Black (AKA Gateway Cape).

Without this patch, after adding to /boot/uEnv.txt:
```
uboot_overlay_addr4=/lib/firmware/BB-GATEWAY-WL1837-00A0.dtbo
``` 
the board boots, but the USB network interfaces are not properly set.