### PR TITLE
boot: Update USB CDC Ethernet gadget to use NCM

### DIFF
--- a/boot/am335x_evm.sh
+++ b/boot/am335x_evm.sh
@@ -481,11 +481,11 @@ run_libcomposite () {
 		fi
 
 		if [ ! "x${USB_NETWORK_CDC_DISABLED}" = "xyes" ]; then
-			mkdir -p functions/ecm.usb0
-			echo ${cpsw_4_mac} > functions/ecm.usb0/host_addr
-			echo ${cpsw_5_mac} > functions/ecm.usb0/dev_addr
+			mkdir -p functions/ncm.usb0
+			echo ${cpsw_4_mac} > functions/ncm.usb0/host_addr
+			echo ${cpsw_5_mac} > functions/ncm.usb0/dev_addr
 
-			ln -s functions/ecm.usb0 configs/c.1/
+			ln -s functions/ncm.usb0 configs/c.1/
 			usb1="enable"
 		fi
 

--- a/boot/bbai.sh
+++ b/boot/bbai.sh
@@ -269,12 +269,12 @@ run_libcomposite_start () {
 	fi
 
 	if [ ! "x${USB_NETWORK_DISABLED}" = "xyes" ]; then
-		mkdir -p functions/ecm.usb0
-		echo ${cpsw_3_mac} > functions/ecm.usb0/host_addr
-		echo ${cpsw_4_mac} > functions/ecm.usb0/dev_addr
+		mkdir -p functions/ncm.usb0
+		echo ${cpsw_3_mac} > functions/ncm.usb0/host_addr
+		echo ${cpsw_4_mac} > functions/ncm.usb0/dev_addr
 
 	#if [ ! "x${USB_NETWORK_DISABLED}" = "xyes" ]; then
-		ln -s functions/ecm.usb0 configs/c.1/
+		ln -s functions/ncm.usb0 configs/c.1/
 	#fi
 
 	fi

--- a/boot/bbai_usb_gadget.sh
+++ b/boot/bbai_usb_gadget.sh
@@ -230,9 +230,9 @@ fi
 		echo 1 > functions/rndis.usb0/os_desc/interface.rndis/Label/type
 		echo "BeagleBone USB Ethernet" > functions/rndis.usb0/os_desc/interface.rndis/Label/data
 
-		mkdir -p functions/ecm.usb0
-		echo ${cpsw_3_mac} > functions/ecm.usb0/host_addr
-		echo ${cpsw_4_mac} > functions/ecm.usb0/dev_addr
+		mkdir -p functions/ncm.usb0
+		echo ${cpsw_3_mac} > functions/ncm.usb0/host_addr
+		echo ${cpsw_4_mac} > functions/ncm.usb0/dev_addr
 	fi
 
 	mkdir -p functions/acm.usb0
@@ -248,7 +248,7 @@ fi
 
 	if [ ! "x${USB_NETWORK_DISABLED}" = "xyes" ]; then
 		ln -s functions/rndis.usb0 configs/c.1/
-		ln -s functions/ecm.usb0 configs/c.1/
+		ln -s functions/ncm.usb0 configs/c.1/
 	fi
 
 	ln -s functions/acm.usb0 configs/c.1/

--- a/boot/beagle_x15.sh
+++ b/boot/beagle_x15.sh
@@ -260,9 +260,9 @@ run_libcomposite () {
 			echo 01 > functions/rndis.usb0/protocol
 		fi
 
-		mkdir -p functions/ecm.usb0
-		echo ${cpsw_4_mac} > functions/ecm.usb0/host_addr
-		echo ${cpsw_5_mac} > functions/ecm.usb0/dev_addr
+		mkdir -p functions/ncm.usb0
+		echo ${cpsw_4_mac} > functions/ncm.usb0/host_addr
+		echo ${cpsw_5_mac} > functions/ncm.usb0/dev_addr
 
 		mkdir -p functions/acm.usb0
 
@@ -283,7 +283,7 @@ run_libcomposite () {
 		echo 500 > configs/c.1/MaxPower
 
 		ln -s functions/rndis.usb0 configs/c.1/
-		ln -s functions/ecm.usb0 configs/c.1/
+		ln -s functions/ncm.usb0 configs/c.1/
 		ln -s functions/acm.usb0 configs/c.1/
 		if [ "x${has_img_file}" = "xtrue" ] ; then
 			ln -s functions/mass_storage.usb0 configs/c.1/


### PR DESCRIPTION
The USB CDC Ethernet gadget is currently configured to use the ECM
protocol.  Unfortunately this protocol is no longer supported by
MacOS hosts.  However, the newer NCM protocol is supported.
The NCM protocol is also supported by Linux hosts.

This patch updates the USB CDC Ethernet gadget configuration scripts
to use the NCM protocol instead of the ECM protocol.

The patch has been tested on MacOS 10.15.4 using a pocketbeagle.
It is untested on other beagle hardware.

Signed-off-by: James Kelly <vk3jpk@gmail.com>