### PR TITLE
use "grep ^root=" instead of "grep root=" when parsing /proc/cmdline

### DIFF
--- a/boot/am335x_evm.sh
+++ b/boot/am335x_evm.sh
@@ -548,11 +548,11 @@ use_libcomposite () {
 	else
 		#We don't use a physical partition anymore...
 		unset root_drive
-		root_drive="$(cat /proc/cmdline | sed 's/ /\n/g' | grep root=UUID= | awk -F 'root=' '{print $2}' || true)"
+		root_drive="$(cat /proc/cmdline | sed 's/ /\n/g' | grep ^root=UUID= | awk -F 'root=' '{print $2}' || true)"
 		if [ ! "x${root_drive}" = "x" ] ; then
 			root_drive="$(/sbin/findfs ${root_drive} || true)"
 		else
-			root_drive="$(cat /proc/cmdline | sed 's/ /\n/g' | grep root= | awk -F 'root=' '{print $2}' || true)"
+			root_drive="$(cat /proc/cmdline | sed 's/ /\n/g' | grep ^root= | awk -F 'root=' '{print $2}' || true)"
 		fi
 
 		if [ "x${root_drive}" = "x/dev/mmcblk0p1" ] || [ "x${root_drive}" = "x/dev/mmcblk1p1" ] ; then
@@ -637,11 +637,11 @@ use_old_g_multi () {
 	else
 		#g_multi: Do we have a non-rootfs "fat" partition?
 		unset root_drive
-		root_drive="$(cat /proc/cmdline | sed 's/ /\n/g' | grep root=UUID= | awk -F 'root=' '{print $2}' || true)"
+		root_drive="$(cat /proc/cmdline | sed 's/ /\n/g' | grep ^root=UUID= | awk -F 'root=' '{print $2}' || true)"
 		if [ ! "x${root_drive}" = "x" ] ; then
 			root_drive="$(/sbin/findfs ${root_drive} || true)"
 		else
-			root_drive="$(cat /proc/cmdline | sed 's/ /\n/g' | grep root= | awk -F 'root=' '{print $2}' || true)"
+			root_drive="$(cat /proc/cmdline | sed 's/ /\n/g' | grep ^root= | awk -F 'root=' '{print $2}' || true)"
 		fi
 
 		if [ "x${root_drive}" = "x/dev/mmcblk0p1" ] || [ "x${root_drive}" = "x/dev/mmcblk1p1" ] ; then

--- a/tools/eMMC/functions.sh
+++ b/tools/eMMC/functions.sh
@@ -339,11 +339,11 @@ find_root_drive(){
 		proc_cmdline=$(cat /proc/cmdline | tr -d '\000')
 		echo_broadcast "==> ${proc_cmdline}"
 		generate_line 40
-		root_drive=$(cat /proc/cmdline | tr -d '\000' | sed 's/ /\n/g' | grep root=UUID= | awk -F 'root=' '{print $2}' || true)
+		root_drive=$(cat /proc/cmdline | tr -d '\000' | sed 's/ /\n/g' | grep ^root=UUID= | awk -F 'root=' '{print $2}' || true)
 		if [ ! "x${root_drive}" = "x" ] ; then
 			root_drive=$(/sbin/findfs ${root_drive} || true)
 		else
-			root_drive=$(cat /proc/cmdline | sed 's/ /\n/g' | grep root= | awk -F 'root=' '{print $2}' || true)
+			root_drive=$(cat /proc/cmdline | sed 's/ /\n/g' | grep ^root= | awk -F 'root=' '{print $2}' || true)
 		fi
 		echo_broadcast "==> root_drive=[${root_drive}]"
 	else

--- a/tools/eMMC/init-eMMC-flasher-v2.sh
+++ b/tools/eMMC/init-eMMC-flasher-v2.sh
@@ -32,11 +32,11 @@ if ! id | grep -q root; then
 fi
 
 unset root_drive
-root_drive="$(cat /proc/cmdline | sed 's/ /\n/g' | grep root=UUID= | awk -F 'root=' '{print $2}' || true)"
+root_drive="$(cat /proc/cmdline | sed 's/ /\n/g' | grep ^root=UUID= | awk -F 'root=' '{print $2}' || true)"
 if [ ! "x${root_drive}" = "x" ] ; then
 	root_drive="$(/sbin/findfs ${root_drive} || true)"
 else
-	root_drive="$(cat /proc/cmdline | sed 's/ /\n/g' | grep root= | awk -F 'root=' '{print $2}' || true)"
+	root_drive="$(cat /proc/cmdline | sed 's/ /\n/g' | grep ^root= | awk -F 'root=' '{print $2}' || true)"
 fi
 
 boot_drive="${root_drive%?}1"

--- a/tools/generate_extlinux.sh
+++ b/tools/generate_extlinux.sh
@@ -15,11 +15,11 @@ var_cmdline=$(cat /boot/uEnv.txt | grep -v '#' | grep 'cmdline=' || true)
 var_cmdline=${var_cmdline##*cmdline=}
 
 unset root_drive
-root_drive="$(cat /proc/cmdline | sed 's/ /\n/g' | grep root=UUID= | awk -F 'root=' '{print $2}' || true)"
+root_drive="$(cat /proc/cmdline | sed 's/ /\n/g' | grep ^root=UUID= | awk -F 'root=' '{print $2}' || true)"
 if [ ! "x${root_drive}" = "x" ] ; then
 	root_drive="$(/sbin/findfs ${root_drive} || true)"
 else
-	root_drive="$(cat /proc/cmdline | sed 's/ /\n/g' | grep root= | awk -F 'root=' '{print $2}' || true)"
+	root_drive="$(cat /proc/cmdline | sed 's/ /\n/g' | grep ^root= | awk -F 'root=' '{print $2}' || true)"
 fi
 
 var_file_system="console=ttyO0,115200n8 root=${root_drive} ro rootfstype=ext4"

--- a/tools/grow_partition.sh
+++ b/tools/grow_partition.sh
@@ -31,11 +31,11 @@ if [ ! -f /etc/ssh/ssh_host_ecdsa_key.pub ] ; then
 fi
 
 unset root_drive
-root_drive="$(cat /proc/cmdline | sed 's/ /\n/g' | grep root=UUID= | awk -F 'root=' '{print $2}' || true)"
+root_drive="$(cat /proc/cmdline | sed 's/ /\n/g' | grep ^root=UUID= | awk -F 'root=' '{print $2}' || true)"
 if [ ! "x${root_drive}" = "x" ] ; then
 	root_drive="$(/sbin/findfs ${root_drive} || true)"
 else
-	root_drive="$(cat /proc/cmdline | sed 's/ /\n/g' | grep root= | awk -F 'root=' '{print $2}' || true)"
+	root_drive="$(cat /proc/cmdline | sed 's/ /\n/g' | grep ^root= | awk -F 'root=' '{print $2}' || true)"
 fi
 
 if [ ! "x${root_drive}" = "x" ] ; then


### PR DESCRIPTION
To avoid confused by something like "overlayroot=" or "nfsroot=".

Signed-off-by: Atsushi Nemoto <atsushi.nemoto@sord.co.jp>