### PR TITLE
added conf_rootfs_partition_size

### DIFF
--- a/tools/eMMC/functions.sh
+++ b/tools/eMMC/functions.sh
@@ -1284,6 +1284,7 @@ __EOF__
     boot_partition="${destination}p1"
     rootfs_partition="${destination}p2"
   else
+    conf_rootfs_partition_size=${conf_rootfs_partition_size:-""}
     conf_boot_startmb=${conf_boot_startmb:-"4"}
     sfdisk_fstype=${sfdisk_fstype:-"L"}
     if [ "x${sfdisk_fstype}" = "x0x83" ] ; then
@@ -1315,7 +1316,7 @@ __EOF__
     echo_broadcast "==> Partitionning"
     generate_line 60
     LC_ALL=C sfdisk ${sfdisk_options} "${destination}" <<-__EOF__
-${sfdisk_boot_startmb},,${sfdisk_fstype},*
+${sfdisk_boot_startmb},${conf_rootfs_partition_size},${sfdisk_fstype},*
 __EOF__
     generate_line 60
     flush_cache


### PR DESCRIPTION
Setting the conf_rootfs_partition_size variable allows for better control over the size of the microSD card necessary to house the resulting image when running the beaglebone-black-make-microSD-flasher-from-eMMC.sh script. For example, you might be working with a 32GB microSD card image, but want to generate an image that would also fit on a 4GB microSD card, so you could do the following:
sudo conf_rootfs_partition_size=7462912 /opt/scripts/tools/eMMC/beaglebone-black-make-microSD-flasher-from-eMMC.sh

Which would specify the size as 7462912 sectors, which is the size of the eMMC rootfs partition (at least on the one I was testing on). After making the flasher you could then use dd to get the image off the microSD card for flashing onto other microSD cards:

sudo dd if=<path to microSD card device> of=<your image name> bs=512 count=7471104

7471104 can be determined by the output from fdisk -l (one more than the End sector, or 8192 more than the size of the rootfs partition):
Device         Boot Start     End Sectors  Size Id Type
/dev/mmcblk0p1 *     8192 7471103 7462912  3.6G 83 Linux

You may be able to speed up the dd command by using a bigger blocksize and adjusting the count accordingly (using a 4MB block size):
sudo dd if=<path to microSD card device> of=<your image name> bs=419430 count=912