### PR TITLE
change path from /resizerootfs to /var/resizerootfs 

### DIFF
--- a/boot/generic-startup.sh
+++ b/boot/generic-startup.sh
@@ -58,14 +58,14 @@ if [ -f /boot/efi/EFI/efi.gen ] ; then
 fi
 
 #Resize drive when requested
-if [ -f /resizerootfs ] ; then
+if [ -f /var/resizerootfs ] ; then
 	echo "generic-board-startup: resizerootfs"
 
 	unset is_btrfs
 	is_btrfs=$(cat /proc/cmdline | grep btrfs || true)
 
 	if [ "x${is_btrfs}" = "x" ] ; then
-		drive=$(cat /resizerootfs)
+		drive=$(cat /var/resizerootfs)
 		if [ ! "x${drive}" = "x" ] ; then
 			echo "generic-board-startup: "
 			if [ "x${drive}" = "x/dev/mmcblk0" ] || [ "x${drive}" = "x/dev/mmcblk1" ] ; then
@@ -81,7 +81,7 @@ if [ -f /resizerootfs ] ; then
 		btrfs filesystem resize max / >/var/log/resize.log 2>&1 || true
 	fi
 
-	rm -rf /resizerootfs || true
+	rm -rf /var/resizerootfs || true
 	sync
 fi
 

--- a/tools/grow_partition.sh
+++ b/tools/grow_partition.sh
@@ -46,7 +46,7 @@ else
 fi
 
 single_partition () {
-	echo "${drive}p1" > /resizerootfs
+	echo "${drive}p1" > /var/resizerootfs
 	conf_boot_startmb=${conf_boot_startmb:-"4"}
 	sfdisk_fstype=${sfdisk_fstype:-"L"}
 	if [ "x${sfdisk_fstype}" = "x0x83" ] ; then
@@ -67,7 +67,7 @@ single_partition () {
 }
 
 dual_partition () {
-	echo "${drive}p2" > /resizerootfs
+	echo "${drive}p2" > /var/resizerootfs
 	conf_boot_startmb=${conf_boot_startmb:-"4"}
 	conf_boot_endmb=${conf_boot_endmb:-"96"}
 	sfdisk_fstype=${sfdisk_fstype:-"E"}


### PR DESCRIPTION
I've made progress getting a process in place that can convert a Beaglebone image to an ostree-managed version of it. When the ostree-managed system is running, the root directory (/) is actually a bind mount to a path buried in the ostree repository (something like /ostree/boot.1/debian/72448a25b05b4af57ed48c72bea09e50643b90bfaad5125bfd022a6aa67aac2c/0). /var is a better place to write to as it remains a mutable location to store files. In this pull request, I switched tools/grow_partition.sh and boot/generic-startup.sh to write to /var rather than /.

See https://github.com/ostreedev/ostree/issues/2357 for more info about the ostree conversion.