### PR TITLE
add rsync -X option

### DIFF
--- a/tools/developers/nfs-rsync.sh
+++ b/tools/developers/nfs-rsync.sh
@@ -21,7 +21,7 @@ echo "sudo mkdir /tmp/rootfs/"
 echo "sudo mount -t nfs -o rw,nfsvers=3,rsize=8192,wsize=8192 192.168.0.12:/opt/${dist}/ /tmp/rootfs/"
 
 if [ -d /tmp/rootfs/ ] ; then
-	sudo rsync -aAx --human-readable --info=name0,progress2 --delete /* /tmp/rootfs/ --exclude={/dev/*,/proc/*,/sys/*,/tmp/*,/run/*,/mnt/*,/media/*,/lost+found}
+	sudo rsync -aAXx --human-readable --info=name0,progress2 --delete /* /tmp/rootfs/ --exclude={/dev/*,/proc/*,/sys/*,/tmp/*,/run/*,/mnt/*,/media/*,/lost+found}
 	sudo sh -c "echo 'debugfs  /sys/kernel/debug  debugfs  defaults  0  0' > /tmp/rootfs/etc/fstab"
 
 	if [ ! "x${dist}" = "xstretch" ] ;then

--- a/tools/developers/secondary_rootfs.sh
+++ b/tools/developers/secondary_rootfs.sh
@@ -76,7 +76,7 @@ copy_rootfs () {
 	if [ ! "x${rsync_progress}" = "x" ] ; then
 		echo "rsync: note the % column is useless..."
 	fi
-	rsync -aAx ${rsync_progress} /* /tmp/rootfs/ --exclude={/dev/*,/proc/*,/sys/*,/tmp/*,/run/*,/mnt/*,/media/*,/lost+found,/lib/modules/*,/uEnv.txt}
+	rsync -aAXx ${rsync_progress} /* /tmp/rootfs/ --exclude={/dev/*,/proc/*,/sys/*,/tmp/*,/run/*,/mnt/*,/media/*,/lost+found,/lib/modules/*,/uEnv.txt}
 	#flush_cache
 
 	mkdir -p /tmp/rootfs/lib/modules/$(uname -r)/ || true
@@ -86,7 +86,7 @@ copy_rootfs () {
 	if [ ! "x${rsync_progress}" = "x" ] ; then
 		echo "rsync: note the % column is useless..."
 	fi
-	rsync -aAx ${rsync_progress} /lib/modules/$(uname -r)/* /tmp/rootfs/lib/modules/$(uname -r)/
+	rsync -aAXx ${rsync_progress} /lib/modules/$(uname -r)/* /tmp/rootfs/lib/modules/$(uname -r)/
 	#flush_cache
 
 	message="Copying: ${source}p${media_rootfs} -> ${destination}${media_rootfs} complete" ; broadcast

--- a/tools/eMMC/bbb-eMMC-flasher-eewiki-12mb.sh
+++ b/tools/eMMC/bbb-eMMC-flasher-eewiki-12mb.sh
@@ -181,7 +181,7 @@ copy_boot () {
 	fi
 
 	message="rsync: /boot/uboot/ -> /tmp/boot/" ; broadcast
-	rsync -aAx /boot/uboot/ /tmp/boot/ --exclude={MLO,u-boot.img,uEnv.txt} || write_failure
+	rsync -aAXx /boot/uboot/ /tmp/boot/ --exclude={MLO,u-boot.img,uEnv.txt} || write_failure
 	flush_cache
 
 	flush_cache
@@ -197,7 +197,7 @@ copy_rootfs () {
 	mount ${destination}p${media_rootfs} /tmp/rootfs/ -o async,noatime
 
 	message="rsync: / -> /tmp/rootfs/" ; broadcast
-	rsync -aAx /* /tmp/rootfs/ --exclude={/dev/*,/proc/*,/sys/*,/tmp/*,/run/*,/mnt/*,/media/*,/lost+found,/lib/modules/*,/uEnv.txt} || write_failure
+	rsync -aAXx /* /tmp/rootfs/ --exclude={/dev/*,/proc/*,/sys/*,/tmp/*,/run/*,/mnt/*,/media/*,/lost+found,/lib/modules/*,/uEnv.txt} || write_failure
 	flush_cache
 
 	if [ -d /tmp/rootfs/etc/ssh/ ] ; then
@@ -210,7 +210,7 @@ copy_rootfs () {
 
 	message="Copying: Kernel modules" ; broadcast
 	message="rsync: /lib/modules/$(uname -r)/ -> /tmp/rootfs/lib/modules/$(uname -r)/" ; broadcast
-	rsync -aAx /lib/modules/$(uname -r)/* /tmp/rootfs/lib/modules/$(uname -r)/ || write_failure
+	rsync -aAXx /lib/modules/$(uname -r)/* /tmp/rootfs/lib/modules/$(uname -r)/ || write_failure
 	flush_cache
 
 	message="Copying: ${source}p${media_rootfs} -> ${destination}p${media_rootfs} complete" ; broadcast

--- a/tools/eMMC/bbb-eMMC-flasher-eewiki-ext4.sh
+++ b/tools/eMMC/bbb-eMMC-flasher-eewiki-ext4.sh
@@ -181,7 +181,7 @@ copy_boot () {
 	fi
 
 	message="rsync: /boot/uboot/ -> /tmp/boot/" ; broadcast
-	rsync -aAx /boot/uboot/ /tmp/boot/ --exclude={MLO,u-boot.img,uEnv.txt} || write_failure
+	rsync -aAXx /boot/uboot/ /tmp/boot/ --exclude={MLO,u-boot.img,uEnv.txt} || write_failure
 	flush_cache
 
 	flush_cache
@@ -197,7 +197,7 @@ copy_rootfs () {
 	mount ${destination}p${media_rootfs} /tmp/rootfs/ -o async,noatime
 
 	message="rsync: / -> /tmp/rootfs/" ; broadcast
-	rsync -aAx /* /tmp/rootfs/ --exclude={/dev/*,/proc/*,/sys/*,/tmp/*,/run/*,/mnt/*,/media/*,/lost+found,/lib/modules/*,/uEnv.txt} || write_failure
+	rsync -aAXx /* /tmp/rootfs/ --exclude={/dev/*,/proc/*,/sys/*,/tmp/*,/run/*,/mnt/*,/media/*,/lost+found,/lib/modules/*,/uEnv.txt} || write_failure
 	flush_cache
 
 	if [ -d /tmp/rootfs/etc/ssh/ ] ; then
@@ -210,7 +210,7 @@ copy_rootfs () {
 
 	message="Copying: Kernel modules" ; broadcast
 	message="rsync: /lib/modules/$(uname -r)/ -> /tmp/rootfs/lib/modules/$(uname -r)/" ; broadcast
-	rsync -aAx /lib/modules/$(uname -r)/* /tmp/rootfs/lib/modules/$(uname -r)/ || write_failure
+	rsync -aAXx /lib/modules/$(uname -r)/* /tmp/rootfs/lib/modules/$(uname -r)/ || write_failure
 	flush_cache
 
 	message="Copying: ${source}p${media_rootfs} -> ${destination}p${media_rootfs} complete" ; broadcast

--- a/tools/eMMC/functions.sh
+++ b/tools/eMMC/functions.sh
@@ -869,7 +869,7 @@ _copy_boot() {
 	if [ -f /boot/uboot/MLO ] ; then
 		echo_broadcast "==> rsync: /boot/uboot/ -> ${tmp_boot_dir}"
 		get_rsync_options
-		rsync -aAxv $rsync_options /boot/uboot/* ${tmp_boot_dir} --exclude={MLO,u-boot.img,uEnv.txt} || write_failure
+		rsync -aAXxv $rsync_options /boot/uboot/* ${tmp_boot_dir} --exclude={MLO,u-boot.img,uEnv.txt} || write_failure
 		flush_cache
 		empty_line
 		generate_line 80 '='
@@ -998,7 +998,7 @@ _copy_rootfs() {
   echo_broadcast "==> rsync: / -> ${tmp_rootfs_dir}"
   generate_line 40
   get_rsync_options
-  rsync -aAx $rsync_options /* ${tmp_rootfs_dir} --exclude={/dev/*,/proc/*,/sys/*,/tmp/*,/run/*,/mnt/*,/media/*,/lost+found,/lib/modules/*,/uEnv.txt} || write_failure
+  rsync -aAXx $rsync_options /* ${tmp_rootfs_dir} --exclude={/dev/*,/proc/*,/sys/*,/tmp/*,/run/*,/mnt/*,/media/*,/lost+found,/lib/modules/*,/uEnv.txt} || write_failure
   flush_cache
   generate_line 40
   echo_broadcast "==> Copying: Kernel modules"
@@ -1006,7 +1006,7 @@ _copy_rootfs() {
   mkdir -p ${tmp_rootfs_dir}/lib/modules/$(uname -r)/ || true
   echo_broadcast "===> rsync: /lib/modules/$(uname -r)/ -> ${tmp_rootfs_dir}/lib/modules/$(uname -r)/"
   generate_line 40
-  rsync -aAx $rsync_options /lib/modules/$(uname -r)/* ${tmp_rootfs_dir}/lib/modules/$(uname -r)/ || write_failure
+  rsync -aAXx $rsync_options /lib/modules/$(uname -r)/* ${tmp_rootfs_dir}/lib/modules/$(uname -r)/ || write_failure
   flush_cache
   generate_line 40
 
@@ -1049,7 +1049,7 @@ _copy_rootfs_reverse() {
 	echo_broadcast "==> rsync: / -> ${tmp_rootfs_dir}"
 	generate_line 40
 	get_rsync_options
-	rsync -aAx $rsync_options /* ${tmp_rootfs_dir} --exclude={/dev/*,/proc/*,/sys/*,/tmp/*,/run/*,/mnt/*,/media/*,/lost+found,/lib/modules/*,/uEnv.txt} || write_failure
+	rsync -aAXx $rsync_options /* ${tmp_rootfs_dir} --exclude={/dev/*,/proc/*,/sys/*,/tmp/*,/run/*,/mnt/*,/media/*,/lost+found,/lib/modules/*,/uEnv.txt} || write_failure
 	flush_cache
 	generate_line 40
 	echo_broadcast "==> Copying: Kernel modules"
@@ -1057,7 +1057,7 @@ _copy_rootfs_reverse() {
 	mkdir -p ${tmp_rootfs_dir}/lib/modules/$(uname -r)/ || true
 	echo_broadcast "===> rsync: /lib/modules/$(uname -r)/ -> ${tmp_rootfs_dir}/lib/modules/$(uname -r)/"
 	generate_line 40
-	rsync -aAx $rsync_options /lib/modules/$(uname -r)/* ${tmp_rootfs_dir}/lib/modules/$(uname -r)/ || write_failure
+	rsync -aAXx $rsync_options /lib/modules/$(uname -r)/* ${tmp_rootfs_dir}/lib/modules/$(uname -r)/ || write_failure
 	flush_cache
 	generate_line 40
 

--- a/tools/eMMC/init-eMMC-flasher-from-usb-media-v1-bbgw.sh
+++ b/tools/eMMC/init-eMMC-flasher-from-usb-media-v1-bbgw.sh
@@ -208,7 +208,7 @@ flash_emmc () {
     mount -v -o async,noatime,offset=1048576 -t ext4 /opt/emmc/${conf_image} /tmp/source_rootfs
 
 	message="rsync: /tmp/source_rootfs -> /tmp/dest_rootfs/" ; broadcast
-	rsync -aAx /tmp/source_rootfs/* /tmp/dest_rootfs/ --exclude={/dev/*,/proc/*,/sys/*,/tmp/*,/run/*,/mnt/*,/media/*,/lost+found,/lib/modules/*,/uEnv.txt} || write_failure
+	rsync -aAXx /tmp/source_rootfs/* /tmp/dest_rootfs/ --exclude={/dev/*,/proc/*,/sys/*,/tmp/*,/run/*,/mnt/*,/media/*,/lost+found,/lib/modules/*,/uEnv.txt} || write_failure
 
 	if [ -d /tmp/dest_rootfs/etc/ssh/ ] ; then
 		#ssh keys will now get regenerated on the next bootup
@@ -219,7 +219,7 @@ flash_emmc () {
     mkdir -p /tmp/dest_rootfs/lib/modules/$(uname -r)/ || true
 	message="Copying: Kernel modules" ; broadcast
 	message="rsync: /tmp/source_rootfs/lib/modules/$(uname -r)/ -> /tmp/dest_rootfs/lib/modules/$(uname -r)/" ; broadcast
-	rsync -aAx /tmp/source_rootfs/lib/modules/$(uname -r)/* /tmp/dest_rootfs/lib/modules/$(uname -r)/ || write_failure
+	rsync -aAXx /tmp/source_rootfs/lib/modules/$(uname -r)/* /tmp/dest_rootfs/lib/modules/$(uname -r)/ || write_failure
 	flush_cache
     
 	message="Final System Tweaks:" ; broadcast

--- a/tools/eMMC/init-eMMC-flasher-v3-bbbl.sh
+++ b/tools/eMMC/init-eMMC-flasher-v3-bbbl.sh
@@ -56,7 +56,7 @@ _copy_rootfs() {
   echo_broadcast "==> rsync: / -> ${tmp_rootfs_dir}"
   generate_line 40
   get_rsync_options
-  rsync -aAx $rsync_options /* ${tmp_rootfs_dir} --exclude={/dev/*,/proc/*,/sys/*,/tmp/*,/run/*,/mnt/*,/media/*,/lost+found,/lib/modules/*,/uEnv.txt} || write_failure
+  rsync -aAXx $rsync_options /* ${tmp_rootfs_dir} --exclude={/dev/*,/proc/*,/sys/*,/tmp/*,/run/*,/mnt/*,/media/*,/lost+found,/lib/modules/*,/uEnv.txt} || write_failure
   flush_cache
   generate_line 40
   echo_broadcast "==> Copying: Kernel modules"
@@ -64,7 +64,7 @@ _copy_rootfs() {
   mkdir -p ${tmp_rootfs_dir}/lib/modules/$(uname -r)/ || true
   echo_broadcast "===> rsync: /lib/modules/$(uname -r)/ -> ${tmp_rootfs_dir}/lib/modules/$(uname -r)/"
   generate_line 40
-  rsync -aAx $rsync_options /lib/modules/$(uname -r)/* ${tmp_rootfs_dir}/lib/modules/$(uname -r)/ || write_failure
+  rsync -aAXx $rsync_options /lib/modules/$(uname -r)/* ${tmp_rootfs_dir}/lib/modules/$(uname -r)/ || write_failure
   flush_cache
   generate_line 40
 

--- a/tools/eMMC/init-eMMC-flasher-v3-bbbw.sh
+++ b/tools/eMMC/init-eMMC-flasher-v3-bbbw.sh
@@ -56,7 +56,7 @@ _copy_rootfs() {
   echo_broadcast "==> rsync: / -> ${tmp_rootfs_dir}"
   generate_line 40
   get_rsync_options
-  rsync -aAx $rsync_options /* ${tmp_rootfs_dir} --exclude={/dev/*,/proc/*,/sys/*,/tmp/*,/run/*,/mnt/*,/media/*,/lost+found,/lib/modules/*,/uEnv.txt} || write_failure
+  rsync -aAXx $rsync_options /* ${tmp_rootfs_dir} --exclude={/dev/*,/proc/*,/sys/*,/tmp/*,/run/*,/mnt/*,/media/*,/lost+found,/lib/modules/*,/uEnv.txt} || write_failure
   flush_cache
   generate_line 40
   echo_broadcast "==> Copying: Kernel modules"
@@ -64,7 +64,7 @@ _copy_rootfs() {
   mkdir -p ${tmp_rootfs_dir}/lib/modules/$(uname -r)/ || true
   echo_broadcast "===> rsync: /lib/modules/$(uname -r)/ -> ${tmp_rootfs_dir}/lib/modules/$(uname -r)/"
   generate_line 40
-  rsync -aAx $rsync_options /lib/modules/$(uname -r)/* ${tmp_rootfs_dir}/lib/modules/$(uname -r)/ || write_failure
+  rsync -aAXx $rsync_options /lib/modules/$(uname -r)/* ${tmp_rootfs_dir}/lib/modules/$(uname -r)/ || write_failure
   flush_cache
   generate_line 40
 

--- a/tools/eMMC/init-eMMC-flasher-v3-bbgw.sh
+++ b/tools/eMMC/init-eMMC-flasher-v3-bbgw.sh
@@ -56,7 +56,7 @@ _copy_rootfs() {
   echo_broadcast "==> rsync: / -> ${tmp_rootfs_dir}"
   generate_line 40
   get_rsync_options
-  rsync -aAx $rsync_options /* ${tmp_rootfs_dir} --exclude={/dev/*,/proc/*,/sys/*,/tmp/*,/run/*,/mnt/*,/media/*,/lost+found,/lib/modules/*,/uEnv.txt} || write_failure
+  rsync -aAXx $rsync_options /* ${tmp_rootfs_dir} --exclude={/dev/*,/proc/*,/sys/*,/tmp/*,/run/*,/mnt/*,/media/*,/lost+found,/lib/modules/*,/uEnv.txt} || write_failure
   flush_cache
   generate_line 40
   echo_broadcast "==> Copying: Kernel modules"
@@ -64,7 +64,7 @@ _copy_rootfs() {
   mkdir -p ${tmp_rootfs_dir}/lib/modules/$(uname -r)/ || true
   echo_broadcast "===> rsync: /lib/modules/$(uname -r)/ -> ${tmp_rootfs_dir}/lib/modules/$(uname -r)/"
   generate_line 40
-  rsync -aAx $rsync_options /lib/modules/$(uname -r)/* ${tmp_rootfs_dir}/lib/modules/$(uname -r)/ || write_failure
+  rsync -aAXx $rsync_options /lib/modules/$(uname -r)/* ${tmp_rootfs_dir}/lib/modules/$(uname -r)/ || write_failure
   flush_cache
   generate_line 40
 

--- a/tools/non-mmc-rootfs/mv_rootfs_dev_sda.sh
+++ b/tools/non-mmc-rootfs/mv_rootfs_dev_sda.sh
@@ -76,7 +76,7 @@ copy_rootfs () {
 	if [ ! "x${rsync_progress}" = "x" ] ; then
 		echo "rsync: note the % column is useless..."
 	fi
-	rsync -aAx ${rsync_progress} /* /tmp/rootfs/ --exclude={/dev/*,/proc/*,/sys/*,/tmp/*,/run/*,/mnt/*,/media/*,/lost+found,/lib/modules/*,/uEnv.txt}
+	rsync -aAXx ${rsync_progress} /* /tmp/rootfs/ --exclude={/dev/*,/proc/*,/sys/*,/tmp/*,/run/*,/mnt/*,/media/*,/lost+found,/lib/modules/*,/uEnv.txt}
 	#flush_cache
 
 	mkdir -p /tmp/rootfs/lib/modules/$(uname -r)/ || true
@@ -86,7 +86,7 @@ copy_rootfs () {
 	if [ ! "x${rsync_progress}" = "x" ] ; then
 		echo "rsync: note the % column is useless..."
 	fi
-	rsync -aAx ${rsync_progress} /lib/modules/$(uname -r)/* /tmp/rootfs/lib/modules/$(uname -r)/
+	rsync -aAXx ${rsync_progress} /lib/modules/$(uname -r)/* /tmp/rootfs/lib/modules/$(uname -r)/
 	#flush_cache
 
 	message="Copying: ${source}p${media_rootfs} -> ${destination}${media_rootfs} complete" ; broadcast


### PR DESCRIPTION
Without this, non-root ping cause 'socket: Operation not permitted' error due to missing xattrs.

Signed-off-by: Atsushi Nemoto <atsushi.nemoto@sord.co.jp>

---

Tested only _copy_files() part of function.sh.
Others are done by just replacing by 's/rsync -aAx/rsync -aAXx/' automatically.
