### PR TITLE
Fix parse error for show-pins.pl

### DIFF
--- a/device/bone/show-pins.pl
+++ b/device/bone/show-pins.pl
@@ -126,7 +126,7 @@ while( <> ) {
 		$reg = hex $2;
 		$mux = hex $3;
 	} elsif(/PIN/) {
-		/^pin (\d+) \(PIN\d+\) $addpre([0-9a-f]{4}) ([0-9a-f]{8}) pinctrl-single\z/ or die "parse error";
+		/^pin (\d+) \(PIN\d+\) (?:\d+:\S+)? $addpre([0-9a-f]{4}) ([0-9a-f]{8}) pinctrl-single\z/ or die "parse error";
 		$pin = $1;
 		$reg = hex $2;
 		$mux = hex $3;


### PR DESCRIPTION
This fix worked for me, but I am not a perl expert, I simply tried to apply a script fix from another repository on this version of the script.

See https://github.com/mvduin/bbb-pin-utils/commit/d51ed53ef61935a5e1289d141e9fdd974e2a4f99 for additional information.