### PR TITLE
Do not exit from the _err_trap

### DIFF
--- a/tools/eMMC/functions.sh
+++ b/tools/eMMC/functions.sh
@@ -34,6 +34,8 @@ _err_trap() {
   _showed_traceback=t
   echo "The command ${_cmd} exited with exit code ${_ec}." 1>&2
   teardown_environment
+  reset_leds 'heartbeat' || true
+  inf_loop
 }
 
 _traceback() {


### PR DESCRIPTION
The _exit_trap will be called after _err_trap and LEDs are resetted as OK. Like write_failure, notify the error on LEDs and go inf_loop.